### PR TITLE
fix typespec typo

### DIFF
--- a/lib/nutritionix/client.ex
+++ b/lib/nutritionix/client.ex
@@ -19,7 +19,7 @@ defmodule Nutritionix.Client do
       ...>                                             app_id: "id"})
   """
   @spec new(%{:app_id => String.t(), :app_key => String.t(), :user_id => String.t()}) ::
-          {:error, String.t() | {:ok, Tesla.Client.t()}}
+          {:error, String.t()} | {:ok, Tesla.Client.t()}
   def new(%{user_id: _, app_key: _, app_id: _} = args) do
     try do
       {:ok, new!(args)}

--- a/lib/nutritionix/client.ex
+++ b/lib/nutritionix/client.ex
@@ -41,7 +41,7 @@ defmodule Nutritionix.Client do
       ...>                                       app_id: "id"})
   """
   @spec new!(%{:app_id => String.t(), :app_key => String.t(), :user_id => String.t()}) ::
-          Tesla.Client.t()
+          Tesla.Client.t() | no_return()
   def new!(%{user_id: user_id, app_key: app_key, app_id: app_id}) do
     middleware = [
       {Tesla.Middleware.BaseUrl, @nutritionix_api_baseurl},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Nutritionix.MixProject do
   def project do
     [
       app: :nutritionix,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Fixes a typespec typo that was causing dialyzer to fail.

This is a typespec-only change that is not capable of affecting the runtime code. It's been confirmed to work in a live branch.